### PR TITLE
Fixes default position and fixes testing bar being kept render after GUI closed.

### DIFF
--- a/src/main/java/club/sk1er/bossbarcustomizer/config/BossbarConfig.java
+++ b/src/main/java/club/sk1er/bossbarcustomizer/config/BossbarConfig.java
@@ -5,6 +5,6 @@ public class BossbarConfig {
     public static boolean BOSSBAR_TEXT = true;
     public static boolean BOSSBAR_BAR = true;
     public static double BOSSBAR_X = 0.5;
-    public static double BOSSBAR_Y = 0.025;
+    public static double BOSSBAR_Y = -1;
     public static double SCALE = 1.0;
 }

--- a/src/main/java/club/sk1er/bossbarcustomizer/gui/BossbarGui.java
+++ b/src/main/java/club/sk1er/bossbarcustomizer/gui/BossbarGui.java
@@ -28,6 +28,12 @@ public class BossbarGui extends GuiScreen {
     public void initGui() {
         buttonList.clear();
 
+        if (BossStatus.bossName != null && !BossStatus.bossName.equals("Sk1er LLC")) {
+            previousBossName = BossStatus.bossName;
+            previousStatusBarTime = BossStatus.statusBarTime;
+            previousHealthScale = BossStatus.healthScale;
+        }
+
         BossStatus.bossName = "Sk1er LLC";
         BossStatus.statusBarTime = Integer.MAX_VALUE;
         BossStatus.healthScale = 1F;
@@ -53,11 +59,6 @@ public class BossbarGui extends GuiScreen {
 
     @Override
     public void drawScreen(int mouseX, int mouseY, float partialTicks) {
-        if (BossStatus.bossName != null) {
-            previousBossName = BossStatus.bossName;
-            previousStatusBarTime = BossStatus.statusBarTime;
-            previousHealthScale = BossStatus.healthScale;
-        }
 
         if (this.dragging) {
             BossbarConfig.BOSSBAR_X = (BossbarConfig.BOSSBAR_X * width + (mouseX - this.lastMouseX)) / (double) width;
@@ -112,7 +113,7 @@ public class BossbarGui extends GuiScreen {
                 BossbarConfig.BOSSBAR_TEXT = true;
                 BossbarConfig.BOSSBAR_BAR = true;
                 BossbarConfig.BOSSBAR_X = 0.5;
-                BossbarConfig.BOSSBAR_Y = 0.025;
+                BossbarConfig.BOSSBAR_Y = 12d / this.height;
                 BossbarConfig.SCALE = 1.0;
                 BossbarMod.INSTANCE.saveConfig();
                 initGui();

--- a/src/main/java/club/sk1er/bossbarcustomizer/hook/GuiIngameHook.java
+++ b/src/main/java/club/sk1er/bossbarcustomizer/hook/GuiIngameHook.java
@@ -25,6 +25,10 @@ public class GuiIngameHook extends Gui {
             double scaledWidth = resolution.getScaledWidth();
             double scaledHeight = resolution.getScaledHeight();
 
+            if (BossbarConfig.BOSSBAR_Y == -1d){
+                BossbarConfig.BOSSBAR_Y = 12d / scaledHeight;
+            }
+
             if (BossbarConfig.BOSSBAR_BAR) {
                 int widthLocation = 182;
                 int healthScale = (int) (BossStatus.healthScale * (float) (widthLocation + 1));


### PR DESCRIPTION
Changed `BOSSBAR_Y` default value to `-1` to check before it gets rendered if it is `-1` to set the value to `12 / scaledHeight`.
Changed where it set the previous bossbar values as where it was being set before it was getting the testing bossbar values because the testing bossbar was being set in the init method but the previous bossbar setting was being done in the drawing method which is called after the init which makes the bossbar render forever.